### PR TITLE
Report the number of missing extensions

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -147,6 +147,9 @@ local function extender_place(placepos, placer, itemstack, pointed_thing)
                     if dist <= C.beacon_range + extended then
                         -- upgrade :-)
                         minetest.swap_node(pos, { name = "telemosaic:beacon" })
+                    else
+                        local count = math.ceil(dist - (C.beacon_range + extended))
+                        minetest.chat_send_player(placer:get_player_name(), "You still need to add extensions for "..count.." nodes" )
                     end
                 end
             end


### PR DESCRIPTION
I just added a small chat console message when you place an extension to report the current missing node count.
This should help users knowing how much extensions are still needed and be able to prepare some more interesting extensions mosaic.
